### PR TITLE
'dll_filename' should be uppercase.

### DIFF
--- a/_sdk.py
+++ b/_sdk.py
@@ -12,7 +12,7 @@ dll_path = os.path.dirname(__file__) + os.sep + DLL_FILENAME
 try:
 	_vj = cdll.LoadLibrary(dll_path)
 except OSError:
-	sys.exit("Unable to load vJoy SDK DLL.  Ensure that %s is present" % dll_filename)
+	sys.exit("Unable to load vJoy SDK DLL.  Ensure that %s is present" % DLL_FILENAME)
 
 
 def vJoyEnabled():


### PR DESCRIPTION
Fixes a typo that makes the error message more useful.