### PR TITLE
Fix tidzo/pyvjoy#1, update README as per tidzo/pyvjoy#10

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ pyvjoy is a set of Python bindings for vJoy (vjoystick.sourceforge.net)
 With this library you can easily set Axis and Button values on any vJoy device.  
 Low-level bindings are provided in pyvjoy._sdk as well as a (hopefully) slightly more 'Pythonic' API in the pyvjoy.VJoyDevice() object.
 
-Currently vJoyInterface.dll is looked for inside the pyvjoy directory only so place the desired version of that file there to use.
+Currently vJoyInterface.dll is looked for inside the pyvjoy directory only so place the desired version of that file there to use. (Note: this library currently only works with the x86 dll!)
 
 "Pointy's Joystick Test App" is very useful when testing vJoy and this library: http://www.planetpointy.co.uk/joystick-test-application/
 

--- a/_sdk.py
+++ b/_sdk.py
@@ -142,7 +142,7 @@ def ResetPovs(rID):
 	
 def UpdateVJD(rID, data):
 	"""Pass data for all buttons and axes to vJoy Device efficiently"""
-	return _vj.UpdateVJD(rID, data)
+	return _vj.UpdateVJD(rID, pointer(data))
 
 	
 def CreateDataStructure(rID):

--- a/vjoydevice.py
+++ b/vjoydevice.py
@@ -70,6 +70,8 @@ class VJoyDevice(object):
 		return self._sdk.UpdateVJD(self.rID, self.data)
 
 		
-
+	def __del__(self):
+		# free up the controller before losing access
+		self._sdk.RelinquishVJD(self.rID)
 		
 	


### PR DESCRIPTION
It seems like the access violations occurred when using `VJoyDevice.update()` because the API expected the gamepad data to be passed in as a `(void *)`.
Also, figured it would be good to say in the readme that the library only works with the x86 DLL.

EDIT: Also fixed an issue with the device not always (never?) being relinquished upon deletion.